### PR TITLE
第三方用户登录会影响其他用户信息的bug

### DIFF
--- a/siteuser/users/views.py
+++ b/siteuser/users/views.py
@@ -382,7 +382,7 @@ def social_login_callback(request, sitename):
 
     try:
         user = SocialUser.objects.get(site_uid=site.uid, site_name=site.site_name)
-        SiteUser.objects.filter(id=user.id).update(username=site.name, avatar_url=site.avatar)
+        SiteUser.objects.filter(id=user.user.id).update(username=site.name, avatar_url=site.avatar)
     except SocialUser.DoesNotExist:
         user = SocialUser.objects.create(
             site_uid=site.uid,


### PR DESCRIPTION
在update SiteUser模型的username和avatar_url时，更新的对象不对，filter中的条件应该根据socialUser模型的外键user过滤出SiteUser的id（他们是对应的），原来版本获取到的是与SiteUser主键相等的SocialUser对象。
