### PR TITLE
FixSyntaxs&Redirect

### DIFF
--- a/example/app/templates/home.html
+++ b/example/app/templates/home.html
@@ -48,7 +48,7 @@
             {% if not request.siteuser.is_social %}
             <a href="{% url "account_settings" %}">Settings</a>
             {% endif %}
-            <a href="#" id="siteuserLogout">Logout</a>
+            <a href="{% url "siteuser_logout" %}">Logout</a>
         {% else %}
             <a href="{% url "siteuser_login" %}">Login</a>
             <a href="{% url "siteuser_register" %}">Register</a>

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -187,7 +187,7 @@ BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
 USING_SOCIAL_LOGIN = False
-AVATAR_DIR = os.path.join(EXAMPLE_PATH, 'avatar')
+AVATAR_DIR = os.path.join(EXAMPLE_PATH, 'app/static/avatar')
 
 SITEUSER_ACCOUNT_MIXIN = 'app.siteuser_custom.AccountMixIn'
 SITEUSER_EXTEND_MODEL = 'app.siteuser_custom.SiteUserExtend'
@@ -198,3 +198,12 @@ try:
     from local_settings import *
 except ImportError:
     pass
+
+SITEUSER_EMAIL = {
+    'smtp_host': 'smtp.gmail.com',
+    'smtp_port': 25,
+    'username': 'xxx',
+    'password': 'xxx',
+    'from': 'xxx@gmail.com',
+    'display_from': '',
+}

--- a/siteuser/users/views.py
+++ b/siteuser/users/views.py
@@ -39,7 +39,7 @@ make_password = lambda passwd: hashlib.sha1(passwd).hexdigest()
 def inner_account_ajax_guard(func):
     @wraps(func)
     def deco(self, request, *args, **kwargs):
-        dump = lambda d: HttpResponse(json.dumps(d), mimetype='application/json')
+        dump = lambda d: HttpResponse(json.dumps(d), content_type='application/json')
         if request.siteuser:
             return dump({'ok': False, 'msg': '你已登录'})
 
@@ -363,7 +363,7 @@ def logout(request):
     except:
         pass
 
-    return HttpResponse('', mimetype='application/json')
+    return HttpResponse('', content_type='application/json')
 
 
 


### PR DESCRIPTION
1. 使用content_type替代mimetype，因django1.7后移除对mimetype的支持
2. 修正logout页面的href
3. 修正example的avator默认目录
4. 增加SITEUSER_EMAIL以免初次启动报错